### PR TITLE
Add proxy env support

### DIFF
--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -57,6 +57,9 @@ spec:
           env:
             - name: TERN_CONF
               value: {{ .Values.dbMigrator.configDir }}/tern.conf
+            {{- with .Values.dbMigrator.job.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: db-migrator-config
               mountPath: {{ .Values.dbMigrator.configDir }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -70,10 +70,15 @@ spec:
           securityContext:
             {{-  toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.hub.server.cacheDir }}
+          {{- if or .Values.hub.server.cacheDir .Values.hub.deploy.extraEnvVars }}
           env:
+            {{- if .Values.hub.server.cacheDir }}
             - name: XDG_CACHE_HOME
               value: {{ .Values.hub.server.cacheDir | quote }}
+            {{- end }}
+            {{- with .Values.hub.deploy.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           volumeMounts:
             - name: hub-config

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -55,10 +55,15 @@ spec:
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- if .Values.scanner.cacheDir }}
+              {{- if or .Values.scanner.cacheDir .Values.scanner.cronjob.extraEnvVars }}
               env:
+                {{- if .Values.scanner.cacheDir }}
                 - name: TRIVY_CACHE_DIR
                   value: {{ .Values.scanner.cacheDir | quote }}
+                {{- end }}
+                {{- with .Values.scanner.cronjob.extraEnvVars }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
               {{- end }}
               volumeMounts:
                 - name: scanner-config

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -54,10 +54,15 @@ spec:
               resources:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- if .Values.tracker.cacheDir }}
+              {{- if or .Values.tracker.cacheDir .Values.tracker.cronjob.extraEnvVars }}
               env:
+                {{- if .Values.tracker.cacheDir }}
                 - name: XDG_CACHE_HOME
                   value: {{ .Values.tracker.cacheDir | quote }}
+                {{- end }}
+                {{- with .Values.tracker.cronjob.extraEnvVars }}
+                  {{- toYaml . | nindent 16 }}
+                {{- end }}
               {{- end }}
               volumeMounts:
                 - name: tracker-config

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -38,6 +38,10 @@ spec:
         - name: trivy
           image: {{ .Values.trivy.deploy.image }}
           command: ['trivy', '--debug', '--cache-dir', '/trivy', 'server', '--listen', '0.0.0.0:8081']
+          {{- with .Values.trivy.deploy.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: trivy
               mountPath: "/trivy"

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -106,6 +106,12 @@
                             "default": {},
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         },
+                        "extraEnvVars": {
+                            "title": "Extra environment variables",
+                            "description": "Optionally specify extra list of environment variables for the dbMigrator job",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "securityContext": {
                             "title": "DB migrator pod security context",
                             "type": "object",
@@ -296,6 +302,12 @@
                         "extraVolumeMounts": {
                             "title": "Extra volume mounts",
                             "description": "Optionally specify extra list of additional volume mounts for the hub deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraEnvVars": {
+                            "title": "Extra environment variables",
+                            "description": "Optionally specify extra list of environment variables for the hub deployment",
                             "type": "array",
                             "default": "[]"
                         },
@@ -1047,6 +1059,12 @@
                             "type": "array",
                             "default": "[]"
                         },
+                        "extraEnvVars": {
+                            "title": "Extra environment variables",
+                            "description": "Optionally specify extra list of environment variables for the scanner cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -1171,6 +1189,12 @@
                             "type": "array",
                             "default": "[]"
                         },
+                        "extraEnvVars": {
+                            "title": "Extra environment variables",
+                            "description": "Optionally specify extra list of environment variables for the tracker cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -1286,6 +1310,12 @@
                         "extraVolumeMounts": {
                             "title": "Extra volume mounts",
                             "description": "Optionally specify extra list of additional volume mounts for the trivy deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraEnvVars": {
+                            "title": "Extra environment variables",
+                            "description": "Optionally specify extra list of environment variables for the trivy deployment",
                             "type": "array",
                             "default": "[]"
                         },

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -105,6 +105,8 @@ dbMigrator:
     #   requests:
     #     cpu: 100m
     #     memory: 128Mi
+    # Optionally specify extra list of environment variables for the dbMigrator job
+    extraEnvVars: []
     # Optionally specify a node selector for the dbMigrator pod
     nodeSelector: {}
   # Load demo user and sample repositories
@@ -188,6 +190,8 @@ hub:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the hub deployment
     extraVolumeMounts: []
+    # Optionally specify extra list of environment variables for the hub deployment
+    extraEnvVars: []
     # Optionally specify a node selector for the hub deployment
     nodeSelector: {}
     # Optionally specify extra list of additional containers for the hub deployment
@@ -338,6 +342,8 @@ scanner:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the scanner cronjob
     extraVolumeMounts: []
+    # Optionally specify extra list of environment variables for the scanner cronjob
+    extraEnvVars: []
     # Optionally specify a node selector for the scanner cronjob
     nodeSelector: {}
   # Number of snapshots to process concurrently
@@ -376,6 +382,8 @@ tracker:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the tracker cronjob
     extraVolumeMounts: []
+    # Optionally specify extra list of environment variables for the tracker cronjob
+    extraEnvVars: []
     # Optionally specify a node selector for the tracker cronjob
     nodeSelector: {}
   # Cache directory path. If set, the cache directory for the Helm client will be explicitly set (otherwise defaults
@@ -417,6 +425,8 @@ trivy:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the trivy deployment
     extraVolumeMounts: []
+    # Optionally specify extra list of environment variables for the trivy deployment
+    extraEnvVars: []
     # Optionally specify a node selector for the trivy deployment
     nodeSelector: {}
   persistence:


### PR DESCRIPTION
## Summary
- support extra env vars in main hub Deployment
- support extra env vars in tracker and scanner CronJobs
- support extra env vars in DB migrator Job
- support extra env vars in Trivy Deployment
- document new settings in chart values and schema

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `yarn test --watchAll=false --passWithNoTests --verbose` *(fails: This package doesn't seem to be present in your lockfile)*